### PR TITLE
Deploy Posthog analytics

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -23,6 +23,21 @@
 		</script>
 		<!-- End Google tag -->
 
+		<!-- PostHog Analytics -->
+		<script>
+		  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+		  posthog.init('phc_piV7fJ3FVD36shJkPtiTwpYEV4KKWLpaiWMcNXbh2A5u', {
+		    api_host: 'https://eu.i.posthog.com',
+		    person_profiles: 'identified_only',
+		    capture_pageview: true,
+		    capture_pageleave: true,
+		  });
+		  var uid = localStorage.getItem('uid') || crypto.randomUUID();
+		  localStorage.setItem('uid', uid);
+		  posthog.identify(uid);
+		</script>
+		<!-- End PostHog Analytics -->
+
 	</head>
 	<body class="is-preload">
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,21 @@
 			</script>
 	    <!-- End Google Analytics -->
 
+		<!-- PostHog Analytics -->
+		<script>
+		  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+		  posthog.init('phc_piV7fJ3FVD36shJkPtiTwpYEV4KKWLpaiWMcNXbh2A5u', {
+		    api_host: 'https://eu.i.posthog.com',
+		    person_profiles: 'identified_only',
+		    capture_pageview: true,
+		    capture_pageleave: true,
+		  });
+		  var uid = localStorage.getItem('uid') || crypto.randomUUID();
+		  localStorage.setItem('uid', uid);
+		  posthog.identify(uid);
+		</script>
+		<!-- End PostHog Analytics -->
+
 		<!-- Twemoji: fixes flag emojis on Windows -->
 		<script src="https://cdn.jsdelivr.net/npm/twemoji@14.0.2/dist/twemoji.min.js" crossorigin="anonymous"></script>
 		<style>

--- a/profile.html
+++ b/profile.html
@@ -22,7 +22,22 @@
 			gtag('config', 'G-TSPF8M7G00');
 			</script>
 		<!-- End Google tag -->
-	
+
+		<!-- PostHog Analytics -->
+		<script>
+		  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+		  posthog.init('phc_piV7fJ3FVD36shJkPtiTwpYEV4KKWLpaiWMcNXbh2A5u', {
+		    api_host: 'https://eu.i.posthog.com',
+		    person_profiles: 'identified_only',
+		    capture_pageview: true,
+		    capture_pageleave: true,
+		  });
+		  var uid = localStorage.getItem('uid') || crypto.randomUUID();
+		  localStorage.setItem('uid', uid);
+		  posthog.identify(uid);
+		</script>
+		<!-- End PostHog Analytics -->
+
 	</head>
 	<body class="is-preload">
 

--- a/projects.html
+++ b/projects.html
@@ -23,6 +23,21 @@
 		</script>
 		<!-- End Google tag -->
 
+		<!-- PostHog Analytics -->
+		<script>
+		  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+" (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+		  posthog.init('phc_piV7fJ3FVD36shJkPtiTwpYEV4KKWLpaiWMcNXbh2A5u', {
+		    api_host: 'https://eu.i.posthog.com',
+		    person_profiles: 'identified_only',
+		    capture_pageview: true,
+		    capture_pageleave: true,
+		  });
+		  var uid = localStorage.getItem('uid') || crypto.randomUUID();
+		  localStorage.setItem('uid', uid);
+		  posthog.identify(uid);
+		</script>
+		<!-- End PostHog Analytics -->
+
 		<!-- Twemoji: fixes flag emojis on Windows -->
 		<script src="https://cdn.jsdelivr.net/npm/twemoji@14.0.2/dist/twemoji.min.js" crossorigin="anonymous"></script>
 		<style>

--- a/projects.html
+++ b/projects.html
@@ -139,10 +139,11 @@
 								<span class="tag">fpdf2</span>
 								<span class="tag">Render</span>
 								<span class="tag">Sentry</span>
+								<span class="tag">PostHog</span>
 								<span class="tag">WAT Framework</span>
 							</div>
 							<p><b>Évoli</b> is an AI agent for French learners. Pick a CEFR level (A1–C1) and a topic - the agent autonomously sources a real, current French article, generates 5 comprehension questions, builds a curated vocabulary section with French and English definitions, and scores your answers instantly. Subscribers receive a fresh, personalised styled 4-page exercise every Monday by email - fully automated.</p>
-							<p>Built with <b>Python</b> and <b>Flask</b>, powered by <b>Anthropic Claude API</b> for on-demand content generation. PDF rendering is handled in-memory with <b>fpdf2</b>, subscriber data stored in <b>Supabase</b> (PostgreSQL), and the weekly pipeline is orchestrated by <b>GitHub Actions</b>. Deployed on <b>Render</b> with <b>Sentry</b> for error tracking, following the <b>WAT framework</b> (Workflows → Agent → Tools).</p>
+							<p>Built with <b>Python</b> and <b>Flask</b>, powered by <b>Anthropic Claude API</b> for on-demand content generation. PDF rendering is handled in-memory with <b>fpdf2</b>, subscriber data stored in <b>Supabase</b> (PostgreSQL), and the weekly pipeline is orchestrated by <b>GitHub Actions</b>. Deployed on <b>Render</b> with <b>Sentry</b> for error tracking and <b>PostHog</b> for product analytics, following the <b>WAT framework</b> (Workflows → Agent → Tools).</p>
 							<ul class="actions special">
 								<li><a href="https://fle-agent.onrender.com" class="button primary large" target="_blank" rel="noopener noreferrer">Open App &#8594;</a></li>
 								<li><a href="https://github.com/nuvita97/fle-agent" class="button large" target="_blank" rel="noopener noreferrer">View Code</a></li>


### PR DESCRIPTION
## Add PostHog Analytics

### Summary
- Add PostHog EU cloud snippet to all 4 pages (`index.html`, `profile.html`, `projects.html`, `gallery.html`), alongside the existing Google Analytics
- Use `localStorage` identity (`uid`) to stitch user journeys across pages (static-site approach, no server required)
- Update Évoli project card: add `PostHog` tag and mention it in the description

### What's tracked out of the box
- Page views and page leave (time on page)
- Country, city, device, browser, OS
- Referrer and UTM params
- Persistent anonymous user identity across pages

### Notes
- Token (`phc_…`) is a write-only capture key — safe to expose in frontend code
- Events are routed to EU cloud (`eu.i.posthog.com`) for GDPR compliance
- Google Analytics is kept in parallel for now